### PR TITLE
Add support for innerHTML assignments

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,1 @@
-lib/polymer-styling.js
+lib/bundled-shadycss.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,4 @@
-bower_components
-node_modules
-test/shadow
-test/shady
-test/webcomponentsjs
 .vscode
-example
+node_modules
 tests/generated
+lib/bundled-shadycss.js

--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,0 @@
-bower_components
-node_modules
-test/shadow
-test/shady
-test/webcomponentsjs
-.vscode
-example
-polymer

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ sudo: false
 addons:
   firefox: latest
   chrome: stable
+before_script: npm run bundle
 script: xvfb-run npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 * Add support for inline HTML documents set with `.innerHTML=` syntax
 * Add support for parsing `Polymer({})` elements from Closure Compiler output
 * Add support for `--build-for-shady` and Polymer v1 `::content` selectors
+* Drop `esm` module for manual `rollup` build of `@webcomponents/shadycss`
+  * Too many weird loader issues for various customers
+* Do not mark polymer v1 templates with `css-build` attribute.
+
+## [0.3.2] - 2018-09-12
+* Fix typo in package.json
+* Do not mark polymer v1 templates with `css-build` attribute.
+## [0.3.1] - 2018-09-12
+* Add support for `--build-for-shady` and Polymer v1 `::content` selectors
+* Drop `esm` module for manual `rollup` build of `@webcomponents/shadycss`
+  * Too many weird loader issues for various customers
 
 ## [0.4.0] - 2018-08-21
 * Add support for class based elements and inlined templates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+* Add support for inline HTML documents set with `.innerHTML=` syntax
+* Add support for parsing `Polymer({})` elements from Closure Compiler output
+* Add support for `--build-for-shady` and Polymer v1 `::content` selectors
+
 ## [0.4.0] - 2018-08-21
 * Add support for class based elements and inlined templates
   * `class MyElement extends Polymer.Element {}` + `<dom-module id="my-element">`

--- a/bin/polymer-css-build
+++ b/bin/polymer-css-build
@@ -103,6 +103,11 @@ polycss(docs, args).then((docs) => {
     fs.writeFileSync(outputFiles[idx], d.content, 'utf8');
   });
 }).catch((err) => {
-  console.error(err.message);
-  process.exit(1);
+  if (err.stack) {
+    console.error(err.stack);
+  } else if (err.message) {
+    console.error(err.message);
+  } else {
+    console.error(err);
+  }  process.exit(1);
 })

--- a/dev/shadycss.js
+++ b/dev/shadycss.js
@@ -1,0 +1,28 @@
+/**!
+ * @license
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+/**
+ * @fileoverview
+ *
+ * A library that bundles all the parts of ShadyCSS that polymer-css-build
+ * needs.
+ */
+
+import * as StyleUtil from '@webcomponents/shadycss/src/style-util.js';
+import * as CssParse from '@webcomponents/shadycss/src/css-parse.js';
+
+export {default as StyleTransformer} from '@webcomponents/shadycss/src/style-transformer.js';
+export {default as ApplyShim} from '@webcomponents/shadycss/src/apply-shim.js';
+export {scopingAttribute as ShadyUnscopedAttribute} from '@webcomponents/shadycss/src/unscoped-style-handler.js';
+
+export {StyleUtil, CssParse};

--- a/index.js
+++ b/index.js
@@ -312,7 +312,7 @@ function getDocument(analysis, url) {
 
 function getAstNode(feature) {
   let astNode = feature.astNode;
-  if (astNode.node && astNode.containingDocument) {
+  if (astNode.node) {
     return astNode.node;
   } else {
     return astNode;

--- a/index.js
+++ b/index.js
@@ -539,7 +539,7 @@ async function polymerCssBuild(paths, options = {}) {
     }
     if (polymerElement.domModule) {
       const domModule = polymerElement.domModule;
-      markDomModule(domModule, scope, nativeShadow, analysis, polymerVersion > 1);
+      markDomModule(domModule, scope, nativeShadow, polymerVersion > 1);
       styles = getAndFixDomModuleStyles(domModule);
     } else {
       markPolymerElement(polymerElement, nativeShadow, analysis);

--- a/lib/closure-html-template-scanner.js
+++ b/lib/closure-html-template-scanner.js
@@ -15,11 +15,20 @@ const {ScannedInlineDocument} = require('polymer-analyzer/lib/model/model.js');
 
 const {getIdentifierName, expressionToValue} = require('polymer-analyzer/lib/javascript/ast-value.js');
 
+const jsIdentifierMap = new WeakMap();
+
+function IdentifierIsDocumentVariable(identifier, jsNode) {
+  const variableName = getIdentifierName(identifier);
+  return jsIdentifierMap.get(jsNode) === variableName;
+}
 /**
  * Finds inline HTML documents in Javascript source.
  *
  * e.g.
- *     html`<div></div>`;
+ *     html`<div></div>`; =>
+ *     var f = ["<div></div>"];
+ *     f.raw = ["<div></div>"];
+ *     html(f);
  */
 class ClosureHtmlTemplateScanner {
   async scan(document, visit) {
@@ -27,24 +36,37 @@ class ClosureHtmlTemplateScanner {
 
     let possibleCookedTemplateVariable;
     let possibleCookedTemplateLiteral;
+    let declarationParent;
+
     const myVisitor = {
-      enterVariableDeclarator(node, _parent, path) {
+      enterVariableDeclarator(node, parent) {
         const value = node.init;
-        if (value.type === 'ArrayExpression' && value.elements.every((e) => e.type === 'StringLiteral')) {
+        if (value && value.type === 'ArrayExpression' && value.elements.every((e) => e.type === 'StringLiteral')) {
           possibleCookedTemplateVariable = getIdentifierName(node.id);
           possibleCookedTemplateLiteral = value;
+          declarationParent = parent;
         }
       },
-      enterAssignmentExpression(node) {
+      enterAssignmentExpression(node, _parent, path) {
         if (!possibleCookedTemplateVariable || !possibleCookedTemplateLiteral) {
           return;
         }
         const leftName = getIdentifierName(node.left);
-        if (leftName === `${possibleCookedTemplateVariable}.raw`) {
-          const inlineDocument = getInlineDocument(possibleCookedTemplateLiteral, document);
-          if (inlineDocument !== undefined) {
-            features.push(inlineDocument);
-          }
+        if (leftName !== `${possibleCookedTemplateVariable}.raw`) {
+          return;
+        }
+        const moduleBody = path.parentPath.parent;
+        if (!moduleBody || moduleBody.type !== 'Program') {
+          return;
+        }
+        const index = path.parentPath.key;
+        if (moduleBody.body[index - 1] !== declarationParent) {
+          return;
+        }
+        const inlineDocument = getInlineDocument(possibleCookedTemplateLiteral, document);
+        if (inlineDocument !== undefined) {
+          jsIdentifierMap.set(possibleCookedTemplateLiteral, possibleCookedTemplateVariable);
+          features.push(inlineDocument);
         }
       }
     };
@@ -102,3 +124,4 @@ function getInlineDocument(node, parsedDocument) {
 }
 
 exports.ClosureHtmlTemplateScanner = ClosureHtmlTemplateScanner;
+exports.IdentifierIsDocumentVariable = IdentifierIsDocumentVariable;

--- a/lib/closure-html-template-scanner.js
+++ b/lib/closure-html-template-scanner.js
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+const {ScannedInlineDocument} = require('polymer-analyzer/lib/model/model.js');
+
+const {getIdentifierName, expressionToValue} = require('polymer-analyzer/lib/javascript/ast-value.js');
+
+/**
+ * Finds inline HTML documents in Javascript source.
+ *
+ * e.g.
+ *     html`<div></div>`;
+ */
+class ClosureHtmlTemplateScanner {
+  async scan(document, visit) {
+    const features = [];
+
+    let possibleCookedTemplateVariable;
+    let possibleCookedTemplateLiteral;
+    const myVisitor = {
+      enterVariableDeclarator(node, _parent, path) {
+        const value = node.init;
+        if (value.type === 'ArrayExpression' && value.elements.every((e) => e.type === 'StringLiteral')) {
+          possibleCookedTemplateVariable = getIdentifierName(node.id);
+          possibleCookedTemplateLiteral = value;
+        }
+      },
+      enterAssignmentExpression(node) {
+        if (!possibleCookedTemplateVariable || !possibleCookedTemplateLiteral) {
+          return;
+        }
+        const leftName = getIdentifierName(node.left);
+        if (leftName === `${possibleCookedTemplateVariable}.raw`) {
+          const inlineDocument = getInlineDocument(possibleCookedTemplateLiteral, document);
+          if (inlineDocument !== undefined) {
+            features.push(inlineDocument);
+          }
+        }
+      }
+    };
+
+    await visit(myVisitor);
+
+    return {features};
+  }
+}
+
+/**
+ * Parses the given string as an inline HTML document.
+ */
+function getInlineDocument(node, parsedDocument) {
+  const sourceRangeForLiteral = parsedDocument.sourceRangeForNode(node);
+  if (sourceRangeForLiteral === undefined) {
+    return;
+  }
+  const sourceRangeForContents = {
+    file: sourceRangeForLiteral.file,
+    start: {
+      line: sourceRangeForLiteral.start.line,
+      column: sourceRangeForLiteral.start.column + 1
+    },
+    end: {
+      line: sourceRangeForLiteral.end.line,
+      column: sourceRangeForLiteral.end.column - 1
+    }
+  };
+
+  let contents = expressionToValue(node);
+  if (!Array.isArray(contents)) {
+    return;
+  } else {
+    contents = contents.join();
+  }
+  let commentText;
+  if (node.leadingComments != null) {
+    commentText = node.leadingComments.map((c) => c.value).join('\n');
+  } else {
+    commentText = '';
+  }
+
+  return new ScannedInlineDocument(
+      'html',
+      contents,
+      {
+        filename: sourceRangeForContents.file,
+        col: sourceRangeForContents.start.column,
+        line: sourceRangeForContents.start.line
+      },
+      commentText,
+      sourceRangeForContents,
+      {language: 'js', node, containingDocument: parsedDocument});
+}
+
+exports.ClosureHtmlTemplateScanner = ClosureHtmlTemplateScanner;

--- a/lib/closure-polymer-element-scanner.js
+++ b/lib/closure-polymer-element-scanner.js
@@ -1,0 +1,148 @@
+/**
+ * @license
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+const babel = require('@babel/types');
+
+const {getIdentifierName, expressionToValue} = require('polymer-analyzer/lib/javascript/ast-value.js');
+const esutil = require('polymer-analyzer/lib/javascript/esutil.js');
+const jsdoc = require('polymer-analyzer/lib/javascript/jsdoc.js');
+const {Severity, Warning} = require('polymer-analyzer/lib/model/model.js');
+
+const {declarationPropertyHandlers} = require('polymer-analyzer/lib/polymer/declaration-property-handlers.js');
+const {ScannedPolymerElement} = require('polymer-analyzer/lib/polymer/polymer-element.js');
+
+class ClosurePolymerElementScanner {
+  async scan(
+      document,
+      visit) {
+    const visitor = new ElementVisitor(document);
+    await visit(visitor);
+    return {features: visitor.features, warnings: visitor.warnings};
+  }
+}
+
+/**
+ * Handles Polymer({}) calls.
+ */
+class ElementVisitor {
+  constructor(document) {
+    this.document = document;
+    this.features = [];
+    this.warnings = [];
+  }
+
+  enterCallExpression(
+      node, parent, path) {
+    const callee = node.callee;
+    if (!babel.isIdentifier(callee)) {
+      return;
+    }
+    if (node.arguments.length !== 1) {
+      return;
+    }
+    const argument = node.arguments[0];
+    if (!babel.isObjectExpression(argument)) {
+      return;
+    }
+    const argAsObject = {};
+    for (const prop of esutil.getSimpleObjectProperties(argument)) {
+      const name = esutil.getPropertyName(prop);
+      argAsObject[name] = expressionToValue(prop.value);
+    }
+    if (!argAsObject.is) {
+      return;
+    }
+    const rawDescription = esutil.getAttachedComment(parent);
+    let className = undefined;
+    if (babel.isAssignmentExpression(parent)) {
+      className = getIdentifierName(parent.left);
+    } else if (babel.isVariableDeclarator(parent)) {
+      className = getIdentifierName(parent.id);
+    }
+    const jsDoc = jsdoc.parseJsdoc(rawDescription || '');
+    const element = new ScannedPolymerElement({
+      className,
+      astNode: node,
+      statementAst: esutil.getCanonicalStatement(path),
+      description: jsDoc.description,
+      events: esutil.getEventComments(parent),
+      sourceRange: this.document.sourceRangeForNode(node.arguments[0]),
+      privacy: esutil.getOrInferPrivacy('', jsDoc),
+      abstract: jsdoc.hasTag(jsDoc, 'abstract'),
+      attributes: new Map(),
+      properties: [],
+      behaviors: [],
+      extends: undefined,
+      jsdoc: jsDoc,
+      listeners: [],
+      methods: new Map(),
+      staticMethods: new Map(),
+      mixins: [],
+      observers: [],
+      superClass: undefined,
+      tagName: undefined
+    });
+    element.description = (element.description || '').trim();
+    const propertyHandlers =
+        declarationPropertyHandlers(element, this.document, path);
+
+    if (babel.isObjectExpression(argument)) {
+      this.handleObjectExpression(argument, propertyHandlers, element);
+    }
+
+    this.features.push(element);
+  }
+
+  handleObjectExpression(
+      node, propertyHandlers,
+      element) {
+    for (const prop of esutil.getSimpleObjectProperties(node)) {
+      const name = esutil.getPropertyName(prop);
+      if (!name) {
+        element.warnings.push(new Warning({
+          message: `Can't determine name for property key from expression ` +
+              `with type ${prop.key.type}.`,
+          code: 'cant-determine-property-name',
+          severity: Severity.WARNING,
+          sourceRange: this.document.sourceRangeForNode(prop.key),
+          parsedDocument: this.document
+        }));
+        continue;
+      }
+      if (name in propertyHandlers) {
+        propertyHandlers[name](prop.value);
+      } else if (
+          (babel.isMethod(prop) && prop.kind === 'method') ||
+          babel.isFunction(prop.value)) {
+        const method = esutil.toScannedMethod(
+            prop, this.document.sourceRangeForNode(prop), this.document);
+        element.addMethod(method);
+      }
+    }
+
+    for (const prop of esutil
+             .extractPropertiesFromClassOrObjectBody(node, this.document)
+             .values()) {
+      if (prop.name in propertyHandlers) {
+        continue;
+      }
+      element.addProperty({
+        ...prop,
+        isConfiguration: esutil.configurationProperties.has(prop.name),
+      });
+    }
+  }
+}
+
+exports.ClosurePolymerElementScanner = ClosurePolymerElementScanner;

--- a/lib/innerhtml-assignment-scanner.js
+++ b/lib/innerhtml-assignment-scanner.js
@@ -13,13 +13,13 @@
  */
 const {ScannedInlineDocument} = require('polymer-analyzer/lib/model/model.js');
 
-const {getIdentifierName, expressionToValue} = require('polymer-analyzer/lib/javascript/ast-value.js');
+const {expressionToValue} = require('polymer-analyzer/lib/javascript/ast-value.js');
 
 /**
- * Finds inline HTML documents in Javascript source.
+ * Finds assignments to innerHTML with HTML strings
  *
  * e.g.
- *     html`<div></div>`;
+ *     template.innerHTML = '<div></div>';
  */
 class InnerHtmlAssignmentScanner {
   async scan(document, visit) {

--- a/lib/innerhtml-assignment-scanner.js
+++ b/lib/innerhtml-assignment-scanner.js
@@ -1,0 +1,94 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+const {ScannedInlineDocument} = require('polymer-analyzer/lib/model/model.js');
+
+const {getIdentifierName, expressionToValue} = require('polymer-analyzer/lib/javascript/ast-value.js');
+
+/**
+ * Finds inline HTML documents in Javascript source.
+ *
+ * e.g.
+ *     html`<div></div>`;
+ */
+class InnerHtmlAssignmentScanner {
+  async scan(document, visit) {
+    const features = [];
+
+    const myVisitor = {
+      enterAssignmentExpression(node) {
+        const leftNode = node.left;
+        if (leftNode.type !== 'MemberExpression') {
+          return 'skip';
+        }
+        if (!leftNode.property || leftNode.property.name !== 'innerHTML'){
+          return 'skip';
+        }
+        const inlineDocument = getInlineDocument(node.right, document);
+        if (inlineDocument !== undefined) {
+          features.push(inlineDocument);
+        }
+      }
+    };
+
+    await visit(myVisitor);
+
+    return {features};
+  }
+}
+
+/**
+ * Parses the given string as an inline HTML document.
+ */
+function getInlineDocument(node, parsedDocument) {
+  const sourceRangeForLiteral = parsedDocument.sourceRangeForNode(node);
+  if (sourceRangeForLiteral === undefined) {
+    return;
+  }
+  const sourceRangeForContents = {
+    file: sourceRangeForLiteral.file,
+    start: {
+      line: sourceRangeForLiteral.start.line,
+      column: sourceRangeForLiteral.start.column + 1
+    },
+    end: {
+      line: sourceRangeForLiteral.end.line,
+      column: sourceRangeForLiteral.end.column - 1
+    }
+  };
+
+  let contents = expressionToValue(node);
+  if (typeof contents !== 'string') {
+    return;
+  }
+  let commentText;
+  if (node.leadingComments != null) {
+    commentText = node.leadingComments.map((c) => c.value).join('\n');
+  } else {
+    commentText = '';
+  }
+
+  return new ScannedInlineDocument(
+      'html',
+      contents,
+      {
+        filename: sourceRangeForContents.file,
+        col: sourceRangeForContents.start.column,
+        line: sourceRangeForContents.start.line
+      },
+      commentText,
+      sourceRangeForContents,
+      {language: 'js', node, containingDocument: parsedDocument});
+}
+
+exports.InnerHtmlAssignmentScanner = InnerHtmlAssignmentScanner;

--- a/lib/polymer-1-transforms.js
+++ b/lib/polymer-1-transforms.js
@@ -110,6 +110,25 @@ function slottedToContent(cssText) {
   return cssText.replace(SLOTTED_PAREN, `${CONTENT} > $1`);
 }
 
+function shadyReplaceContent(selector, scope) {
+  if (selector.indexOf(CONTENT) === -1) {
+    return selector;
+  }
+  const contentForm = `.${scope}::content`;
+  const replaceContent = new RegExp(`[+~>]? ${contentForm}`);
+  const end = new RegExp('.' + scope + '$');
+  const beforePseudo = new RegExp('.' + scope + ':');
+  return splitSelectorList(selector).map((sel) => {
+    if (sel.indexOf(contentForm) > -1) {
+      return sel.replace(replaceContent, '')
+          .replace(beforePseudo, ':')
+          .replace(end, '');
+    } else {
+      return sel;
+    }
+  }).join(',');
+}
+
 const COMPLEX_SELECTOR_SEP = ',';
 const CONTENT = '::content';
 const DIR_PAREN = /(.*):dir\((ltr|rtl)\)/;
@@ -121,5 +140,6 @@ const SLOTTED_PAREN = /(?:::slotted)(?:\(((?:\([^)(]*\)|[^)(]*)+?)\))/g;
 
 module.exports = {
   dirShadowTransform,
-  slottedToContent
+  slottedToContent,
+  shadyReplaceContent
 };

--- a/lib/shadycss-entrypoint.js
+++ b/lib/shadycss-entrypoint.js
@@ -12,9 +12,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
  * Load ShadyCSS
  */
 function loadShadyCSS(nativeShadow) {
-  /* enable ES Modules from @webcomponents/shadycss */
-  require = require('esm')(module); //eslint-disable-line no-global-assign
-
   /**
    * Boilerplate for using ShadyCSS in a Node context
    */
@@ -27,11 +24,7 @@ function loadShadyCSS(nativeShadow) {
     }
   };
 
-  const StyleTransformer = require('@webcomponents/shadycss/src/style-transformer.js').default;
-  const StyleUtil = require('@webcomponents/shadycss/src/style-util.js');
-  const ApplyShim = require('@webcomponents/shadycss/src/apply-shim.js').default;
-  const CssParse = require('@webcomponents/shadycss/src/css-parse.js');
-  const {scopingAttribute: ShadyUnscopedAttribute} = require('@webcomponents/shadycss/src/unscoped-style-handler.js');
+  const {StyleTransformer, StyleUtil, ApplyShim, CssParse, ShadyUnscopedAttribute} = require('./bundled-shadycss.js');
 
   /**
    * Apply Shim uses a dynamically create DOM element
@@ -39,7 +32,7 @@ function loadShadyCSS(nativeShadow) {
    *
    * Override with a fixed table for building
    */
-  const initialValues = require('./initial-values.js').initialValues;
+  const {initialValues} = require('./initial-values.js');
   ApplyShim.prototype._getInitialValueForProperty = (property) =>
     initialValues[property] || '';
 

--- a/lib/shadycss-entrypoint.js
+++ b/lib/shadycss-entrypoint.js
@@ -31,6 +31,7 @@ function loadShadyCSS(nativeShadow) {
   const StyleUtil = require('@webcomponents/shadycss/src/style-util.js');
   const ApplyShim = require('@webcomponents/shadycss/src/apply-shim.js').default;
   const CssParse = require('@webcomponents/shadycss/src/css-parse.js');
+  const {scopingAttribute: ShadyUnscopedAttribute} = require('@webcomponents/shadycss/src/unscoped-style-handler.js');
 
   /**
    * Apply Shim uses a dynamically create DOM element
@@ -46,7 +47,8 @@ function loadShadyCSS(nativeShadow) {
     StyleTransformer,
     StyleUtil,
     ApplyShim: new ApplyShim(),
-    CssParse
+    CssParse,
+    ShadyUnscopedAttribute
   };
 }
 

--- a/lib/slim-analyzer-options.js
+++ b/lib/slim-analyzer-options.js
@@ -18,10 +18,10 @@ const {JavaScriptImportScanner} = require('polymer-analyzer/lib/javascript/javas
 const {JavaScriptParser} = require('polymer-analyzer/lib/javascript/javascript-parser.js');
 const {DomModuleScanner} = require('polymer-analyzer/lib/polymer/dom-module-scanner.js');
 const {PolymerElementScanner} = require('polymer-analyzer/lib/polymer/polymer-element-scanner.js');
-const {PseudoElementScanner} = require('polymer-analyzer/lib/polymer/pseudo-element-scanner.js');
 
 const {InnerHtmlAssignmentScanner} = require('./innerhtml-assignment-scanner.js');
 const {ClosureHtmlTemplateScanner} = require('./closure-html-template-scanner.js');
+const {ClosurePolymerElementScanner} = require('./closure-polymer-element-scanner.js');
 
 exports.createScannerMap = function createScannerMap(scanInlineTemplates = true) {
   const map = new Map([
@@ -32,7 +32,6 @@ exports.createScannerMap = function createScannerMap(scanInlineTemplates = true)
         new HtmlScriptScanner(),
         new DomModuleScanner(),
         new HtmlCustomElementReferenceScanner(),
-        new PseudoElementScanner()
       ]
     ],
     [
@@ -40,6 +39,7 @@ exports.createScannerMap = function createScannerMap(scanInlineTemplates = true)
       [
         new PolymerElementScanner(),
         new JavaScriptImportScanner(),
+        new ClosurePolymerElementScanner()
       ]
     ]
   ]);
@@ -50,7 +50,7 @@ exports.createScannerMap = function createScannerMap(scanInlineTemplates = true)
         new ClassScanner(),
         new InlineHtmlDocumentScanner(),
         new InnerHtmlAssignmentScanner(),
-        new ClosureHtmlTemplateScanner()
+        new ClosureHtmlTemplateScanner(),
     );
   }
   return map;

--- a/lib/slim-analyzer-options.js
+++ b/lib/slim-analyzer-options.js
@@ -1,0 +1,64 @@
+/**
+@license
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+const {HtmlCustomElementReferenceScanner} = require('polymer-analyzer/lib/html/html-element-reference-scanner.js');
+const {HtmlImportScanner} = require('polymer-analyzer/lib/html/html-import-scanner.js');
+const {HtmlParser} = require('polymer-analyzer/lib/html/html-parser.js');
+const {HtmlScriptScanner} = require('polymer-analyzer/lib/html/html-script-scanner.js');
+const {ClassScanner} = require('polymer-analyzer/lib/javascript/class-scanner.js');
+const {FunctionScanner} = require('polymer-analyzer/lib/javascript/function-scanner.js');
+const {InlineHtmlDocumentScanner} = require('polymer-analyzer/lib/javascript/html-template-literal-scanner.js');
+const {JavaScriptImportScanner} = require('polymer-analyzer/lib/javascript/javascript-import-scanner.js');
+const {JavaScriptParser} = require('polymer-analyzer/lib/javascript/javascript-parser.js');
+const {DomModuleScanner} = require('polymer-analyzer/lib/polymer/dom-module-scanner.js');
+const {PolymerElementScanner} = require('polymer-analyzer/lib/polymer/polymer-element-scanner.js');
+const {PseudoElementScanner} = require('polymer-analyzer/lib/polymer/pseudo-element-scanner.js');
+
+const {InnerHtmlAssignmentScanner} = require('./innerhtml-assignment-scanner.js');
+const {ClosureHtmlTemplateScanner} = require('./closure-html-template-scanner.js');
+
+exports.createScannerMap = function createScannerMap(scanInlineTemplates = true) {
+  const map = new Map([
+    [
+      'html',
+      [
+        new HtmlImportScanner(),
+        new HtmlScriptScanner(),
+        new DomModuleScanner(),
+        new HtmlCustomElementReferenceScanner(),
+        new PseudoElementScanner()
+      ]
+    ],
+    [
+      'js',
+      [
+        new PolymerElementScanner(),
+        new JavaScriptImportScanner(),
+      ]
+    ]
+  ]);
+  if (scanInlineTemplates) {
+    const jsScanners = map.get('js');
+    jsScanners.push(
+        new FunctionScanner(),
+        new ClassScanner(),
+        new InlineHtmlDocumentScanner(),
+        new InnerHtmlAssignmentScanner(),
+        new ClosureHtmlTemplateScanner()
+    );
+  }
+  return map;
+};
+
+exports.createParserMap = function createParserMap() {
+  return new Map([
+    ['html', new HtmlParser()],
+    ['js', new JavaScriptParser()]
+  ]);
+};

--- a/lib/slim-analyzer-options.js
+++ b/lib/slim-analyzer-options.js
@@ -17,7 +17,7 @@ const {InlineHtmlDocumentScanner} = require('polymer-analyzer/lib/javascript/htm
 const {JavaScriptImportScanner} = require('polymer-analyzer/lib/javascript/javascript-import-scanner.js');
 const {JavaScriptParser} = require('polymer-analyzer/lib/javascript/javascript-parser.js');
 const {DomModuleScanner} = require('polymer-analyzer/lib/polymer/dom-module-scanner.js');
-const {PolymerElementScanner} = require('polymer-analyzer/lib/polymer/polymer-element-scanner.js');
+// const {PolymerElementScanner} = require('polymer-analyzer/lib/polymer/polymer-element-scanner.js');
 
 const {InnerHtmlAssignmentScanner} = require('./innerhtml-assignment-scanner.js');
 const {ClosureHtmlTemplateScanner} = require('./closure-html-template-scanner.js');
@@ -37,7 +37,7 @@ exports.createScannerMap = function createScannerMap(scanInlineTemplates = true)
     [
       'js',
       [
-        new PolymerElementScanner(),
+        // new PolymerElementScanner(),
         new JavaScriptImportScanner(),
         new ClosurePolymerElementScanner()
       ]

--- a/package.json
+++ b/package.json
@@ -9,24 +9,26 @@
   "scripts": {
     "lint": "eslint **/*.js",
     "prepare-tests": "./tests/prepare-tests.sh",
-    "test": "npm run lint && npm run prepare-tests && wct"
+    "test": "npm run lint && npm run prepare-tests && wct",
+    "bundle": "rollup -c rollup.config.js"
   },
   "author": "The Polymer Authors",
   "license": "BSD-3-Clause",
   "devDependencies": {
+    "@webcomponents/shadycss": "^1.5.0",
     "babel-eslint": "^8.2.6",
     "bower": "^1.8.4",
     "eslint": "^4.19.1",
     "eslint-plugin-html": "^4.0.5",
+    "rollup": "^0.65.2",
+    "rollup-plugin-node-resolve": "^3.4.0",
     "wct-browser-legacy": "^1.0.1",
     "web-component-tester": "^6.7.1"
   },
   "dependencies": {
-    "@webcomponents/shadycss": "^1.5.0",
     "command-line-args": "^5.0.2",
     "command-line-usage": "^5.0.5",
     "dom5": "^3.0.1",
-    "esm": "^3.0.72",
     "polymer-analyzer": "^3.1.0"
   },
   "directories": {
@@ -43,5 +45,14 @@
   "bugs": {
     "url": "https://github.com/PolymerLabs/polymer-css-build/issues"
   },
-  "homepage": "https://github.com/PolymerLabs/polymer-css-build#readme"
+  "homepage": "https://github.com/PolymerLabs/polymer-css-build#readme",
+  "files": [
+    "package.json",
+    "index.js",
+    "README",
+    "CHANGELOG.md",
+    "LICENSE",
+    "bin/*",
+    "lib/*"
+  ]
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+import resolve from 'rollup-plugin-node-resolve';
+
+export default {
+  input: 'dev/shadycss.js',
+  output: {
+    file: 'lib/bundled-shadycss.js',
+    format: 'cjs'
+  },
+  plugins: [
+    resolve()
+  ]
+};

--- a/tests/app/index.html
+++ b/tests/app/index.html
@@ -121,7 +121,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       const dm = Polymer.DomModule.import('x-app');
       assert(dm.hasAttribute('css-build'), 'dom-module should have css-build attribute');
       const template = dm.querySelector('template');
-      assert(template.hasAttribute('css-build'), 'dom-module template should have css-build attribute');
+      const shouldHaveMarkedTemplate = polymerVersion !== 'polymer1';
+      assert(!(template.hasAttribute('css-build') ^ shouldHaveMarkedTemplate), `dom-module template should ${shouldHaveMarkedTemplate ? 'not ' : ''}have css-build attribute`);
     });
 
     if (polymerVersion === 'polymer2') {


### PR DESCRIPTION
- Add support for `template.innerHTML` assignments to detecting inline HTML documents
- Add support for reading the output of Closure Compiler to detect elements (only for `Polymer({})`) calls
- Add support for Polymer v1 `::content` selectors and `--build-for-shady` flag
- [x] CHANGELOG.md has been updated